### PR TITLE
Cleanup the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 NXDK_DIR = $(CURDIR)/../nxdk
 NXDK_NET = y
 
-XBE_TITLE = triangle
+XBE_TITLE = nxdk-rdt
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(wildcard $(CURDIR)/*.c)
 SHADER_OBJS = ps.inl vs.inl
 
 SRCS += $(CURDIR)/lib/protobuf-c/protobuf-c.c
 
-CFLAGS_EXTRA += -I$(CURDIR)
-CFLAGS_EXTRA += -I$(CURDIR)/lib
+CFLAGS += -I$(CURDIR)
+CFLAGS += -I$(CURDIR)/lib
 
 include $(NXDK_DIR)/Makefile
 


### PR DESCRIPTION
* The title in the makefile was bad. Changed to "nxdk-rdt"
* ~~The `clean_local` target was renamed to `clean-local` (feels more Makefile'ish) and it also calls the global `clean` now instead of overwriting it (So you can actually create a clean project directory for rebuilding)~~ (This change was removed as the old approach also worked)
* `CFLAGS_EXTRA` was not being used by NXDK and overall it feels like `CFLAGS` should be used (Debatable)

Depends on https://github.com/xqemu/nxdk/pull/11